### PR TITLE
Immich: Read file in chunks for upload

### DIFF
--- a/src/immich_upload_daemon/files.py
+++ b/src/immich_upload_daemon/files.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 
+import aiofiles
 from loguru import logger
 from watchdog.events import FileSystemEventHandler
 
@@ -96,3 +97,12 @@ async def scan_existing_files(paths: list[str], db: Database, new_file_event: as
         new_file_event.set()
 
     logger.info("Finished scanning existing files.")
+
+
+async def file_chunk_generator(file_path, chunk_size=8192):
+    async with aiofiles.open(file_path, 'rb') as f:
+        while True:
+            chunk = await f.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk

--- a/src/immich_upload_daemon/immich.py
+++ b/src/immich_upload_daemon/immich.py
@@ -1,13 +1,15 @@
 import aiohttp
-import aiofiles
 import os
 
 from datetime import datetime
 from loguru import logger
 
+from .files import file_chunk_generator
+
 async def upload(base_url: str, api_key: str, file: str) -> bool:
     logger.info(f'Uploading {file}...')
     stats = os.stat(file)
+    file_size = os.stat(file).st_size
 
     headers = {
         'Accept': 'application/json',
@@ -20,30 +22,47 @@ async def upload(base_url: str, api_key: str, file: str) -> bool:
         'deviceId': 'python',
         'fileCreatedAt': datetime.fromtimestamp(stats.st_mtime).isoformat(),
         'fileModifiedAt': datetime.fromtimestamp(stats.st_mtime).isoformat(),
+        'fileSize': str(file_size),
         'isFavorite': 'false',
     }
 
-    async with aiohttp.ClientSession() as session:
-        # Build the form-data for upload.
-        form = aiohttp.FormData()
-        for key, value in data.items():
-            form.add_field(key, value)
-        
-        async with aiofiles.open(file, 'rb') as f:
-            file_data = await f.read()
-            form.add_field('assetData',
-                           file_data,
-                           filename=os.path.basename(file),
-                           content_type='application/octet-stream')
+    timeout = aiohttp.ClientTimeout(total=60*60)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            # Build the form-data for upload.
+            form = aiohttp.FormData()
+            for key, value in data.items():
+                form.add_field(key, value)
+            
+            file_iter = file_chunk_generator(file, chunk_size=8192)
+            file_payload = aiohttp.AsyncIterablePayload(
+                file_iter,
+                size=file_size,
+                content_type='application/octet-stream',
+            )
+            form.add_field(
+                'assetData',
+                file_payload,
+                filename=os.path.basename(file),
+                content_type='application/octet-stream'
+            )
 
-        async with session.post(f'{base_url}/assets', headers=headers, data=form) as response:
-            response_json = await response.json()
-            status = response_json.get('status')
-            if status == 'created':
-                logger.success(f'{file} uploaded successfully')
-                return True
-            elif status == 'duplicate':
-                logger.warning(f'{file} is duplicate of {response_json.get("id")}')
-                return True
-            logger.error(f'Failed to upload {file}: {response_json}')
-            return False
+            async with session.post(f'{base_url}/assets', headers=headers, data=form) as response:
+                status = response.status
+                if status not in [200, 201]:
+                    logger.error(f'Failed to upload {file}: {await response.text()}')
+                    return False
+
+                response_json = await response.json()
+                status = response_json.get('status')
+                if status == 'created':
+                    logger.success(f'{file} uploaded successfully')
+                    return True
+                elif status == 'duplicate':
+                    logger.warning(f'{file} is duplicate of {response_json.get("id")}')
+                    return True
+                logger.error(f'Failed to upload {file}: {response_json}')
+                return False
+    except Exception as e:
+        logger.error(f"Failed to upload {file}: {e}")
+        return False


### PR DESCRIPTION
Read file in chunks instead of all at once to massively cut back the memory requirements.

This lets me upload a 4gb 30 min video in about 5 mins and a 19gb 124 min video in about 28 mins. It also keeps the memory usage less than 100 mb instead of before where the entire video would try to get loaded in memory and crash everything.