### PR TITLE
systemd: Use default.target

### DIFF
--- a/systemd/immich_upload_daemon.service
+++ b/systemd/immich_upload_daemon.service
@@ -11,4 +11,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Use default instead of multi-user since you are supposed to use this is user mode.